### PR TITLE
fix for renderAjax()

### DIFF
--- a/MarkdownEditor.php
+++ b/MarkdownEditor.php
@@ -523,7 +523,7 @@ EOT;
         // Move iframe at the end of the body
         $view->registerJs('jQuery("body").append(jQuery("#' . $this->_iframeId . '"));');
         // Initialize markdown editor after iframe is loaded
-        $js = 'jQuery(window).load(function(){initEditor(' . Json::encode($params) . ')});';
+        $js = 'jQuery(function(){initEditor(' . Json::encode($params) . ')});';
         $view->registerJs($js);
     }
 


### PR DESCRIPTION
If we getting a form using renderAjax method, editor can't initialize markdown. I fixed it on this commit.
