### PR TITLE
Alter hyperlink and image buttons to prompt for title

### DIFF
--- a/src/assets/js/kv-markdown.js
+++ b/src/assets/js/kv-markdown.js
@@ -88,11 +88,15 @@
                 case 4:  // New Line
                     return $h.getBlockMarkUp(txt, '', '  ');
                 case 5:  // Hyperlink
+                    if (txt == '') {
+                        txt = prompt('Insert title', '')
+                    }
                     link = prompt('Insert Hyperlink', 'http://')
                     return (link != null && link != '' && link != 'http://') ? '[' + txt + '](' + link + ')' : txt;
                 case 6:  // Image
                     link = prompt('Insert Image Hyperlink', 'http://')
-                    return (link != null && link != '' && link != 'http://') ? '![' + txt + '](' + link + ' "enter image title here")' : txt;
+                    var title = prompt('Image title', 'enter image title here')
+                    return (link != null && link != '' && link != 'http://') ? '![' + txt + '](' + link + ' ' + title + ')' : txt;
                 case 7:  // Add Indent
                     if (str.indexOf('\n') < 0) {
                         str = ind + str

--- a/src/assets/js/kv-markdown.js
+++ b/src/assets/js/kv-markdown.js
@@ -94,9 +94,9 @@
                     link = prompt('Insert Hyperlink', 'http://')
                     return (link != null && link != '' && link != 'http://') ? '[' + txt + '](' + link + ')' : txt;
                 case 6:  // Image
-                    link = prompt('Insert Image Hyperlink', 'http://')
                     var title = prompt('Image title', 'enter image title here')
-                    return (link != null && link != '' && link != 'http://') ? '![' + txt + '](' + link + ' ' + title + ')' : txt;
+                    link = prompt('Insert Image Hyperlink', 'http://')
+                    return (link != null && link != '' && link != 'http://') ? '![' + txt + '](' + link + ' "' + title + '")' : txt;
                 case 7:  // Add Indent
                     if (str.indexOf('\n') < 0) {
                         str = ind + str


### PR DESCRIPTION
## Scope
This pull request includes a

- [ ] Bug fix
- [x] New feature
- [ ] Translation

On the front end, the button which collects the parameters for the hyerlink leaves it blank when nothing is selected. It should prompt for a title. The image button enters "enter image title here" as the title when it should prompt for it.

This pull request contains a fix for them both.
 