### PR TITLE
Set icon for `code` button on BS3

### DIFF
--- a/CHANGE.md
+++ b/CHANGE.md
@@ -1,6 +1,10 @@
 Change Log: `yii2-markdown`
 ==========================
 
+## Unreleased
+
+- fix php8 deprecation working when using bs3 (@maxxer)
+
 ## Version 1.3.1
 
 *Date:* 21-Sep-2018

--- a/src/MarkdownEditor.php
+++ b/src/MarkdownEditor.php
@@ -590,7 +590,7 @@ EOT;
                 'buttons' => [
                     self::BTN_CODE => [
                         'label' => $isBs4 ? null : self::ICON_CODE,
-                        'icon' => $isBs4 ? 'code' : null,
+                        'icon' => $this->isBs(4) || $this->isBs(3) ? 'code' : null,
                         'title' => Yii::t('kvmarkdown', 'Inline Code'),
                         'encodeLabel' => false,
                     ],


### PR DESCRIPTION
Avoid error with php8+

```
2023-02-28 15:33:01 [172.30.252.1][7][15as3uabns0bevi5gp2li7vpaf][error][yii\base\ErrorException:8192] yii\base\ErrorException: trim(): Passing null to parameter #1 ($string) of type string is deprecated in /dati/www/vendor/kartik-v/yii2-markdown/src/MarkdownEditor.php:378
Stack trace:
```

## Scope
This pull request includes a

- [x] Bug fix
- [ ] New feature
- [ ] Translation

## Changes
The following changes were made (this change is also documented in the [change log](https://github.com/kartik-v/yii2-markdown/blob/master/CHANGE.md)):

- fix php8 deprecation working when using bs3

## Related Issues
If this is related to an existing ticket, include a link to it as well.